### PR TITLE
fix input password type

### DIFF
--- a/src/Mon/QcmBundle/Form/UserType.php
+++ b/src/Mon/QcmBundle/Form/UserType.php
@@ -17,7 +17,7 @@ class UserType extends AbstractType
         $builder
             ->add('email')
             ->add('name')
-            ->add('password')
+            ->add('password', 'password')
         ;
     }
     


### PR DESCRIPTION
The password input field was "text".
So I just add 'password' in the field type to the password field in Form/UserType.php
