### PR TITLE
fix security.context deprecated in SF 2.6

### DIFF
--- a/src/Mon/QcmBundle/Controller/SecurityController.php
+++ b/src/Mon/QcmBundle/Controller/SecurityController.php
@@ -12,7 +12,7 @@ class SecurityController extends Controller
 {
     public function loginAction(Request $request)
     {
-        if ($this->get('security.context')->isGranted('IS_AUTHENTICATED_FULLY')) {
+        if ($this->get('security.authorization_checker')->isGranted('IS_AUTHENTICATED_FULLY')) {
             return $this->redirect($this->generateUrl('mon_qcm_homepage'));
         }
 
@@ -33,7 +33,7 @@ class SecurityController extends Controller
 
     public function registerAction(Request $request)
     {
-        if ($this->get('security.context')->isGranted('IS_AUTHENTICATED_FULLY') | $this->get('security.context')->isGranted('IS_AUTHENTICATED_REMEMBERME')) {
+        if ($this->get('security.authorization_checker')->isGranted('IS_AUTHENTICATED_FULLY') | $this->get('security.authorization_checker')->isGranted('IS_AUTHENTICATED_REMEMBERME')) {
             return $this->redirect($this->generateUrl('mon_qcm_homepage'));
         }
 

--- a/src/Mon/QcmBundle/Menu/Builder.php
+++ b/src/Mon/QcmBundle/Menu/Builder.php
@@ -3,7 +3,8 @@
 namespace Mon\QcmBundle\Menu;
 
 use Knp\Menu\FactoryInterface;
-use Symfony\Component\Security\Core\SecurityContextInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 class Builder
 {
@@ -18,14 +19,14 @@ class Builder
     }
 
 
-    public function mainMenu(SecurityContextInterface $securityContext)
+    public function mainMenu(AuthorizationCheckerInterface $authorizationCheckerInterface)
     {
         // Menu will be a navbar menu anchored to right
         $menu = $this->factory->createItem('root', array(
             'navbar' => true
         ));
 
-        if (!$securityContext->isGranted('ROLE_USER')) {
+        if (!$authorizationCheckerInterface->isGranted('ROLE_USER')) {
 
             $menu->addChild('Contact', array('route' => 'mon_qcm_contact'));
 
@@ -35,14 +36,14 @@ class Builder
         $menu->addChild('Home', array('route' => 'mon_qcm_homepage'));
         $menu->addChild('Contact', array('route' => 'mon_qcm_contact'));
 
-        if ($securityContext->isGranted('ROLE_ADMIN')) {
+        if ($authorizationCheckerInterface->isGranted('ROLE_ADMIN')) {
             $menu->addChild('Admin', array('route' => 'mon_qcm_admin_qcm'));
         }
 
         return $menu;
     }
 
-    public function userMenu(SecurityContextInterface $securityContext)
+    public function userMenu(AuthorizationCheckerInterface $authorizationCheckerInterface, TokenStorage $tokenStorage)
     {
         // Menu will be a navbar menu anchored to right
         $menu = $this->factory->createItem('root', array(
@@ -50,12 +51,12 @@ class Builder
             'pull-right' => true
         ));
 
-        if (!$securityContext->isGranted('ROLE_USER')) {
+        if (!$authorizationCheckerInterface->isGranted('ROLE_USER')) {
             return $menu;
         }
 
         // Create a dropdown with a caret
-        $dropdown = $menu->addChild($securityContext->getToken()->getUser()->getName(), array(
+        $dropdown = $menu->addChild($tokenStorage->getToken()->getUser()->getName(), array(
             'dropdown' => true,
             'caret' => true,
         ));

--- a/src/Mon/QcmBundle/Resources/config/services.xml
+++ b/src/Mon/QcmBundle/Resources/config/services.xml
@@ -14,12 +14,13 @@
         </service>
 
         <service id="mon_qcm.menu.main" class="Knp\Menu\MenuItem" factory-service="mon_qcm.menu.builder" factory-method="mainMenu">
-            <argument type="service" id="security.context" />
+            <argument type="service" id="security.authorization_checker" />
             <tag name="knp_menu.menu" alias="main" />
         </service>
 
         <service id="mon_qcm.menu.user" class="Knp\Menu\MenuItem" factory-service="mon_qcm.menu.builder" factory-method="userMenu">
-            <argument type="service" id="security.context" />
+            <argument type="service" id="security.authorization_checker" />
+            <argument type="service" id="security.token_storage" />
             <tag name="knp_menu.menu" alias="user" />
         </service>
     </services>


### PR DESCRIPTION
security.context is deprecated in Symfony 2.6
I fixed it according to the documentation : http://symfony.com/blog/new-in-symfony-2-6-security-component-improvements
